### PR TITLE
Remove role tag, return address, not IPs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 A Terraform module to create bastion machine(s) for [Joyent's Triton Compute service](https://www.joyent.com/triton/compute).
 
+> :information_source: _Note: This module requires that 
+[Container Name Service (CNS)](https://docs.joyent.com/public-cloud/network/cns) is enabled.
+
 ## Usage
 
 ```hcl

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -1,10 +1,18 @@
 #
 # Outputs
 #
-output "bastion_ip" {
-  value = ["${module.bastion.bastion_ip}"]
+output "bastion_primary_ip" {
+  value = ["${module.bastion.bastion_primary_ip}"]
 }
 
 output "bastion_user" {
   value = ["${module.bastion.bastion_user}"]
+}
+
+output "bastion_public_address" {
+  value = "${module.bastion.bastion_public_address}"
+}
+
+output "bastion_cns_service_name" {
+  value = "${module.bastion.bastion_cns_service_name}"
 }

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -1,18 +1,10 @@
 #
 # Outputs
 #
-output "bastion_primary_ip" {
-  value = ["${module.bastion.bastion_primary_ip}"]
-}
-
 output "bastion_user" {
-  value = ["${module.bastion.bastion_user}"]
+  value = "${module.bastion.bastion_user}"
 }
 
-output "bastion_public_address" {
-  value = "${module.bastion.bastion_public_address}"
-}
-
-output "bastion_cns_service_name" {
-  value = "${module.bastion.bastion_cns_service_name}"
+output "bastion_address" {
+  value = "${module.bastion.bastion_address}"
 }

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ data "triton_account" "current" {}
 # Locals
 #
 locals {
-  bastion_public_address = "${var.cns_service_name}.svc.${data.triton_account.current.id}.${data.triton_datacenter.current.name}.${var.public_cns_fqdn_base}"
+  bastion_address = "${var.cns_service_name}.svc.${data.triton_account.current.id}.${data.triton_datacenter.current.name}.${var.cns_fqdn_base}"
 }
 
 #

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,21 @@ terraform {
 }
 
 provider "triton" {
-  version = ">= 0.4.0"
+  version = ">= 0.4.1"
+}
+
+#
+# Data sources
+#
+data "triton_datacenter" "current" {}
+
+data "triton_account" "current" {}
+
+#
+# Locals
+#
+locals {
+  bastion_public_address = "${var.cns_service_name}.svc.${data.triton_account.current.id}.${data.triton_datacenter.current.name}.${var.public_cns_fqdn_base}"
 }
 
 #
@@ -23,19 +37,15 @@ resource "triton_machine" "bastion" {
 
   networks = ["${var.networks}"]
 
-  tags {
-    role = "${var.role_tag_value}"
-  }
-
   cns {
     services = ["${var.cns_service_name}"]
   }
 }
 
 resource "triton_firewall_rule" "ssh" {
-  count = "${length(var.ssh_client_access)}"
+  count = "${length(var.client_access)}"
 
-  rule        = "FROM ${var.ssh_client_access[count.index]} TO tag \"role\" = \"${var.role_tag_value}\" ALLOW tcp PORT 22"
+  rule        = "FROM ${var.client_access[count.index]} TO tag \"triton.cns.services\" = \"${var.cns_service_name}\" ALLOW tcp PORT 22"
   enabled     = true
   description = "${var.name} - Allow access from clients to Bastion servers."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,7 @@
 #
 # Outputs
 #
-output "bastion_ip" {
+output "bastion_primary_ip" {
   value = ["${triton_machine.bastion.*.primaryip}"]
 }
 
@@ -9,8 +9,8 @@ output "bastion_user" {
   value = "${var.user}"
 }
 
-output "bastion_role_tag" {
-  value = "${var.role_tag_value}"
+output "bastion_public_address" {
+  value = "${local.bastion_public_address}"
 }
 
 output "bastion_cns_service_name" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,8 +9,8 @@ output "bastion_user" {
   value = "${var.user}"
 }
 
-output "bastion_public_address" {
-  value = "${local.bastion_public_address}"
+output "bastion_address" {
+  value = "${local.bastion_address}"
 }
 
 output "bastion_cns_service_name" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,7 @@
 #
 # Outputs
 #
-output "bastion_primary_ip" {
+output "bastion_primaryip" {
   value = ["${triton_machine.bastion.*.primaryip}"]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -37,7 +37,7 @@ EOF
   default = "root"
 }
 
-variable "ssh_client_access" {
+variable "client_access" {
   description = <<EOF
 'From' targets to allow clients to access the Bastion machines' ssh port - i.e. access from other VMs or public internet.
 See https://docs.joyent.com/public-cloud/network/firewall/cloud-firewall-rules-reference#target
@@ -48,14 +48,14 @@ EOF
   default = ["any"]
 }
 
-variable "role_tag_value" {
-  description = "The 'role' tag value to assign to the Bastion machine(s)."
-  type        = "string"
-  default     = "bastion"
-}
-
 variable "cns_service_name" {
   description = "The Bastion CNS service name. Note: this is the service name only, not the full CNS record."
   type        = "string"
   default     = "bastion"
+}
+
+variable "public_cns_fqdn_base" {
+  description = "The _public_ fully qualified domain name base for the CNS address - e.g. 'triton.zone' for Joyent Public Cloud."
+  type        = "string"
+  default     = "triton.zone"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -54,8 +54,8 @@ variable "cns_service_name" {
   default     = "bastion"
 }
 
-variable "public_cns_fqdn_base" {
-  description = "The _public_ fully qualified domain name base for the CNS address - e.g. 'triton.zone' for Joyent Public Cloud."
+variable "cns_fqdn_base" {
+  description = "The fully qualified domain name base for the CNS address - e.g. 'triton.zone' for Joyent Public Cloud."
   type        = "string"
   default     = "triton.zone"
 }


### PR DESCRIPTION
Simplify usage to use CNS names, not role tag for access. Expose CNS address to use for downstream modules.

Breaking changes. Will require modules downstream to be updated.