### PR TITLE
Use root module provider

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,4 +1,15 @@
 #
+# Terraform/Providers
+#
+terraform {
+  required_version = ">= 0.11.0"
+}
+
+provider "triton" {
+  version = ">= 0.4.1"
+}
+
+#
 # Data Sources
 #
 data "triton_image" "ubuntu" {

--- a/main.tf
+++ b/main.tf
@@ -5,10 +5,6 @@ terraform {
   required_version = ">= 0.11.0"
 }
 
-provider "triton" {
-  version = ">= 0.4.1"
-}
-
 #
 # Data sources
 #


### PR DESCRIPTION
Right now if you attempt to remove resources created with this module terraform will fail because the triton provider from the module will be removed, and therefore doesn't exist to remove any of the resources created with it. Best practice is to put the provider only in your root module and pass it into any modules you use. This can be done explicitly or implicitly. To keep this change minimal I just moved it to the example as an implicit use of the same provider.

For more information on best practices when creating providers see: https://www.terraform.io/docs/modules/usage.html#providers-within-modules